### PR TITLE
Decrease verbosity if IP from HTTP Header is used

### DIFF
--- a/proxy/proxy.go
+++ b/proxy/proxy.go
@@ -922,7 +922,7 @@ func (p *Proxy) remoteAddr(r *http.Request) (net.Addr, error) {
 
 	ip := getIPFromHTTPRequest(r)
 	if ip != nil {
-		log.Info("Using IP address from HTTP request: %s", ip)
+		log.Debug("Using IP address from HTTP request: %s", ip)
 	} else {
 		ip = net.ParseIP(host)
 		if ip == nil {


### PR DESCRIPTION
I am using this project as dependency in a public DoH resolver and get spammed by this line.
I think it would be more appropriate to decrease this log line to debug