### PR TITLE
User-definable EDNS Client Address

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ Application Options:
   -s, --all-servers   Use parallel queries to speed up resolving by querying all upstream servers simultaneously
   -d, --ipv6-disabled Disable IPv6. All AAAA requests will be replied with No Error response code and empty answer 
       --edns          Use EDNS Client Subnet extension
-      --ednsaddr=     Send EDNS Client Address
+      --edns-addr=    Send EDNS Client Address
       --version       Prints the program version
 
 Help Options:

--- a/README.md
+++ b/README.md
@@ -43,10 +43,11 @@ Application Options:
   -s, --all-servers   Use parallel queries to speed up resolving by querying all upstream servers simultaneously
   -d, --ipv6-disabled Disable IPv6. All AAAA requests will be replied with No Error response code and empty answer 
       --edns          Use EDNS Client Subnet extension
+      --ednsaddr=     Send EDNS Client Address
+      --version       Prints the program version
 
 Help Options:
   -h, --help        Show this help message
-  --version         Print DNS proxy version
 ```
 
 ## Examples

--- a/main.go
+++ b/main.go
@@ -72,6 +72,9 @@ type Options struct {
 	// Use EDNS Client Subnet extension
 	EnableEDNSSubnet bool `long:"edns" description:"Use EDNS Client Subnet extension" optional:"yes" optional-value:"true"`
 
+	// User Custom EDNS Client Address
+	EDNSAddr string `long:"ednsaddr" description:"Send EDNS Client Address"`
+
 	// Print DNSProxy version (just for the help)
 	Version bool `long:"version" description:"Prints the program version"`
 }
@@ -146,6 +149,7 @@ func run(options Options) {
 // createProxyConfig creates proxy.Config from the command line arguments
 func createProxyConfig(options Options) proxy.Config {
 	listenIP := net.ParseIP(options.ListenAddr)
+	ednsIP := net.ParseIP(options.EDNSAddr)
 	if listenIP == nil {
 		log.Fatalf("cannot parse %s", options.ListenAddr)
 	}
@@ -166,6 +170,7 @@ func createProxyConfig(options Options) proxy.Config {
 		RefuseAny:                options.RefuseAny,
 		AllServers:               options.AllServers,
 		EnableEDNSClientSubnet:   options.EnableEDNSSubnet,
+		EDNSAddr:                 ednsIP,
 	}
 
 	if options.Fallbacks != nil {

--- a/main.go
+++ b/main.go
@@ -72,8 +72,8 @@ type Options struct {
 	// Use EDNS Client Subnet extension
 	EnableEDNSSubnet bool `long:"edns" description:"Use EDNS Client Subnet extension" optional:"yes" optional-value:"true"`
 
-	// User Custom EDNS Client Address
-	EDNSAddr string `long:"ednsaddr" description:"Send EDNS Client Address"`
+	// Use Custom EDNS Client Address
+	EDNSAddr string `long:"edns-addr" description:"Send EDNS Client Address"`
 
 	// Print DNSProxy version (just for the help)
 	Version bool `long:"version" description:"Prints the program version"`
@@ -149,9 +149,13 @@ func run(options Options) {
 // createProxyConfig creates proxy.Config from the command line arguments
 func createProxyConfig(options Options) proxy.Config {
 	listenIP := net.ParseIP(options.ListenAddr)
-	ednsIP := net.ParseIP(options.EDNSAddr)
 	if listenIP == nil {
 		log.Fatalf("cannot parse %s", options.ListenAddr)
+	}
+
+	ednsIP := net.ParseIP(options.EDNSAddr)
+	if ednsIP == nil {
+		log.Fatalf("cannot parse %s", options.EDNSAddr)
 	}
 
 	// Init upstreams

--- a/proxy/proxy.go
+++ b/proxy/proxy.go
@@ -420,6 +420,7 @@ func (p *Proxy) processECS(d *DNSContext) {
 				clientIP = addr.IP
 			}
 		}
+
 		if clientIP != nil && isPublicIP(clientIP) {
 			ip, mask = setECS(d.Req, clientIP, 0)
 			log.Debug("Set ECS data: %s/%d", ip, mask)


### PR DESCRIPTION
If dnsproxy is used as a secondary dns service, the correct public IP of client cannot be obtained usually.
With this patch, user can define his EDNS Client Address.