### PR TITLE
fix logging: DoH is using GET but logged as POST

### DIFF
--- a/upstream/upstream_doh.go
+++ b/upstream/upstream_doh.go
@@ -72,7 +72,7 @@ func (p *dnsOverHTTPS) exchangeHTTPSClient(m *dns.Msg, client *http.Client) (*dn
 		defer resp.Body.Close()
 	}
 	if err != nil {
-		return nil, errorx.Decorate(err, "couldn't do a POST request to '%s'", p.boot.address)
+		return nil, errorx.Decorate(err, "couldn't do a GET request to '%s'", p.boot.address)
 	}
 
 	body, err := ioutil.ReadAll(resp.Body)


### PR DESCRIPTION
Hi, 

It seems there is a small typo in the log that may cause confusion.

https://github.com/AdguardTeam/dnsproxy/blob/2f7a50c830677fd6fed48a071a5f8f4ff563c1a8/upstream/upstream_doh.go#L64

https://github.com/AdguardTeam/dnsproxy/blob/2f7a50c830677fd6fed48a071a5f8f4ff563c1a8/upstream/upstream_doh.go#L75