### PR TITLE
add --insecure flag to set TlsInsecureSkipVerify

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,7 @@ Application Options:
   -y, --dnscrypt-port=   Listening ports for DNSCrypt
   -c, --tls-crt=         Path to a file with the certificate chain
   -k, --tls-key=         Path to a file with the private key
+      --insecure         Disable secure TLS certificate validation
   -g, --dnscrypt-config= Path to a file with DNSCrypt configuration. You can generate one using https://github.com/ameshkov/dnscrypt
   -u, --upstream=        An upstream to be used (can be specified multiple times)
   -b, --bootstrap=       Bootstrap DNS for DoH and DoT, can be specified multiple times (default: 8.8.8.8:53)

--- a/main.go
+++ b/main.go
@@ -50,6 +50,9 @@ type Options struct {
 	// DNSCrypt listen ports
 	DNSCryptListenPorts []int `short:"y" long:"dnscrypt-port" description:"Listening ports for DNSCrypt"`
 
+	// Disable TLS certificate verification
+	Insecure bool `short:"i" long:"insecure" description:"Disable secure TLS certificate validation" optional:"yes" optional-value:"false"`
+
 	// Encryption config
 	// --
 
@@ -228,7 +231,7 @@ func createProxyConfig(options Options) proxy.Config {
 // initUpstreams inits upstream-related config
 func initUpstreams(config *proxy.Config, options Options) {
 	// Init upstreams
-	upstreamConfig, err := proxy.ParseUpstreamsConfig(options.Upstreams, options.BootstrapDNS, defaultTimeout)
+	upstreamConfig, err := proxy.ParseUpstreamsConfig(options.Upstreams, options.BootstrapDNS, defaultTimeout, options.Insecure)
 	if err != nil {
 		log.Fatalf("error while parsing upstreams configuration: %s", err)
 	}

--- a/main.go
+++ b/main.go
@@ -231,7 +231,7 @@ func createProxyConfig(options Options) proxy.Config {
 // initUpstreams inits upstream-related config
 func initUpstreams(config *proxy.Config, options Options) {
 	// Init upstreams
-	upstreamConfig, err := proxy.ParseUpstreamsConfig(options.Upstreams, options.BootstrapDNS, defaultTimeout, upstream.Options{InsecureSkipVerify: options.Insecure})
+	upstreamConfig, err := proxy.ParseUpstreamsConfig(options.Upstreams, upstream.Options{InsecureSkipVerify: options.Insecure, Bootstrap: options.BootstrapDNS, Timeout: defaultTimeout})
 	if err != nil {
 		log.Fatalf("error while parsing upstreams configuration: %s", err)
 	}

--- a/main.go
+++ b/main.go
@@ -50,9 +50,6 @@ type Options struct {
 	// DNSCrypt listen ports
 	DNSCryptListenPorts []int `short:"y" long:"dnscrypt-port" description:"Listening ports for DNSCrypt"`
 
-	// Disable TLS certificate verification
-	Insecure bool `short:"i" long:"insecure" description:"Disable secure TLS certificate validation" optional:"yes" optional-value:"false"`
-
 	// Encryption config
 	// --
 
@@ -61,6 +58,9 @@ type Options struct {
 
 	// Path to the file with the private key
 	TLSKeyPath string `short:"k" long:"tls-key" description:"Path to a file with the private key"`
+
+	// Disable TLS certificate verification
+	Insecure bool `long:"insecure" description:"Disable secure TLS certificate validation" optional:"yes" optional-value:"false"`
 
 	// Path to the DNSCrypt configuration file
 	DNSCryptConfigPath string `short:"g" long:"dnscrypt-config" description:"Path to a file with DNSCrypt configuration. You can generate one using https://github.com/ameshkov/dnscrypt"`
@@ -231,7 +231,7 @@ func createProxyConfig(options Options) proxy.Config {
 // initUpstreams inits upstream-related config
 func initUpstreams(config *proxy.Config, options Options) {
 	// Init upstreams
-	upstreamConfig, err := proxy.ParseUpstreamsConfig(options.Upstreams, options.BootstrapDNS, defaultTimeout, options.Insecure)
+	upstreamConfig, err := proxy.ParseUpstreamsConfig(options.Upstreams, options.BootstrapDNS, defaultTimeout, upstream.Options{InsecureSkipVerify: options.Insecure})
 	if err != nil {
 		log.Fatalf("error while parsing upstreams configuration: %s", err)
 	}

--- a/proxy/proxy_test.go
+++ b/proxy/proxy_test.go
@@ -105,7 +105,7 @@ func TestExchangeWithReservedDomains(t *testing.T) {
 
 	// upstreams specification. Domains adguard.com and google.ru reserved with fake upstreams, maps.google.ru excluded from dnsmasq.
 	upstreams := []string{"[/adguard.com/]1.2.3.4", "[/google.ru/]2.3.4.5", "[/maps.google.ru/]#", "1.1.1.1"}
-	config, err := ParseUpstreamsConfig(upstreams, []string{"8.8.8.8"}, 1*time.Second, upstream.Options{InsecureSkipVerify: false})
+	config, err := ParseUpstreamsConfig(upstreams, upstream.Options{InsecureSkipVerify: false, Bootstrap: []string{"8.8.8.8"}, Timeout: 1 * time.Second})
 	if err != nil {
 		t.Fatalf("Error while upstream config parsing: %s", err)
 	}

--- a/proxy/proxy_test.go
+++ b/proxy/proxy_test.go
@@ -105,7 +105,7 @@ func TestExchangeWithReservedDomains(t *testing.T) {
 
 	// upstreams specification. Domains adguard.com and google.ru reserved with fake upstreams, maps.google.ru excluded from dnsmasq.
 	upstreams := []string{"[/adguard.com/]1.2.3.4", "[/google.ru/]2.3.4.5", "[/maps.google.ru/]#", "1.1.1.1"}
-	config, err := ParseUpstreamsConfig(upstreams, []string{"8.8.8.8"}, 1*time.Second)
+	config, err := ParseUpstreamsConfig(upstreams, []string{"8.8.8.8"}, 1*time.Second, false)
 	if err != nil {
 		t.Fatalf("Error while upstream config parsing: %s", err)
 	}

--- a/proxy/proxy_test.go
+++ b/proxy/proxy_test.go
@@ -105,7 +105,7 @@ func TestExchangeWithReservedDomains(t *testing.T) {
 
 	// upstreams specification. Domains adguard.com and google.ru reserved with fake upstreams, maps.google.ru excluded from dnsmasq.
 	upstreams := []string{"[/adguard.com/]1.2.3.4", "[/google.ru/]2.3.4.5", "[/maps.google.ru/]#", "1.1.1.1"}
-	config, err := ParseUpstreamsConfig(upstreams, []string{"8.8.8.8"}, 1*time.Second, false)
+	config, err := ParseUpstreamsConfig(upstreams, []string{"8.8.8.8"}, 1*time.Second, upstream.Options{InsecureSkipVerify: false})
 	if err != nil {
 		t.Fatalf("Error while upstream config parsing: %s", err)
 	}

--- a/proxy/upstreams.go
+++ b/proxy/upstreams.go
@@ -25,7 +25,7 @@ type UpstreamConfig struct {
 // So the following config: ["[/host.com/]1.2.3.4", "[/www.host.com/]2.3.4.5", "[/maps.host.com/]#", "3.4.5.6"]
 // will send queries for *.host.com to 1.2.3.4, except for *.www.host.com, which will go to 2.3.4.5 and *.maps.host.com,
 // which will go to default server 3.4.5.6 with all other domains
-func ParseUpstreamsConfig(upstreamConfig, bootstrapDNS []string, timeout time.Duration, insecureSkipVerify bool) (UpstreamConfig, error) {
+func ParseUpstreamsConfig(upstreamConfig, bootstrapDNS []string, timeout time.Duration, options upstream.Options) (UpstreamConfig, error) {
 	var upstreams []upstream.Upstream
 	domainReservedUpstreams := map[string][]upstream.Upstream{}
 
@@ -51,7 +51,7 @@ func ParseUpstreamsConfig(upstreamConfig, bootstrapDNS []string, timeout time.Du
 			dnsUpstream, ok := upstreamsIndex[u]
 			if !ok {
 				// create an upstream
-				dnsUpstream, err = upstream.AddressToUpstream(u, upstream.Options{Bootstrap: bootstrapDNS, Timeout: timeout, InsecureSkipVerify: insecureSkipVerify})
+				dnsUpstream, err = upstream.AddressToUpstream(u, upstream.Options{Bootstrap: bootstrapDNS, Timeout: timeout, InsecureSkipVerify: options.InsecureSkipVerify})
 				if err != nil {
 					return UpstreamConfig{}, fmt.Errorf("cannot prepare the upstream %s (%s): %s", l, bootstrapDNS, err)
 				}

--- a/proxy/upstreams.go
+++ b/proxy/upstreams.go
@@ -2,11 +2,9 @@ package proxy
 
 import (
 	"fmt"
-	"strings"
-	"time"
-
 	"github.com/AdguardTeam/golibs/log"
 	"github.com/AdguardTeam/golibs/utils"
+	"strings"
 
 	"github.com/AdguardTeam/dnsproxy/upstream"
 )
@@ -25,12 +23,12 @@ type UpstreamConfig struct {
 // So the following config: ["[/host.com/]1.2.3.4", "[/www.host.com/]2.3.4.5", "[/maps.host.com/]#", "3.4.5.6"]
 // will send queries for *.host.com to 1.2.3.4, except for *.www.host.com, which will go to 2.3.4.5 and *.maps.host.com,
 // which will go to default server 3.4.5.6 with all other domains
-func ParseUpstreamsConfig(upstreamConfig, bootstrapDNS []string, timeout time.Duration, options upstream.Options) (UpstreamConfig, error) {
+func ParseUpstreamsConfig(upstreamConfig []string, options upstream.Options) (UpstreamConfig, error) {
 	var upstreams []upstream.Upstream
 	domainReservedUpstreams := map[string][]upstream.Upstream{}
 
-	if len(bootstrapDNS) > 0 {
-		log.Debug("Bootstraps: %v", bootstrapDNS)
+	if len(options.Bootstrap) > 0 {
+		log.Debug("Bootstraps: %v", options.Bootstrap)
 	}
 
 	// We use this index to avoid creating duplicates of upstreams
@@ -51,9 +49,9 @@ func ParseUpstreamsConfig(upstreamConfig, bootstrapDNS []string, timeout time.Du
 			dnsUpstream, ok := upstreamsIndex[u]
 			if !ok {
 				// create an upstream
-				dnsUpstream, err = upstream.AddressToUpstream(u, upstream.Options{Bootstrap: bootstrapDNS, Timeout: timeout, InsecureSkipVerify: options.InsecureSkipVerify})
+				dnsUpstream, err = upstream.AddressToUpstream(u, upstream.Options{Bootstrap: options.Bootstrap, Timeout: options.Timeout, InsecureSkipVerify: options.InsecureSkipVerify})
 				if err != nil {
-					return UpstreamConfig{}, fmt.Errorf("cannot prepare the upstream %s (%s): %s", l, bootstrapDNS, err)
+					return UpstreamConfig{}, fmt.Errorf("cannot prepare the upstream %s (%s): %s", l, options.Bootstrap, err)
 				}
 
 				// save to the index

--- a/proxy/upstreams.go
+++ b/proxy/upstreams.go
@@ -2,9 +2,10 @@ package proxy
 
 import (
 	"fmt"
+	"strings"
+
 	"github.com/AdguardTeam/golibs/log"
 	"github.com/AdguardTeam/golibs/utils"
-	"strings"
 
 	"github.com/AdguardTeam/dnsproxy/upstream"
 )

--- a/proxy/upstreams.go
+++ b/proxy/upstreams.go
@@ -25,7 +25,7 @@ type UpstreamConfig struct {
 // So the following config: ["[/host.com/]1.2.3.4", "[/www.host.com/]2.3.4.5", "[/maps.host.com/]#", "3.4.5.6"]
 // will send queries for *.host.com to 1.2.3.4, except for *.www.host.com, which will go to 2.3.4.5 and *.maps.host.com,
 // which will go to default server 3.4.5.6 with all other domains
-func ParseUpstreamsConfig(upstreamConfig, bootstrapDNS []string, timeout time.Duration) (UpstreamConfig, error) {
+func ParseUpstreamsConfig(upstreamConfig, bootstrapDNS []string, timeout time.Duration, insecureSkipVerify bool) (UpstreamConfig, error) {
 	var upstreams []upstream.Upstream
 	domainReservedUpstreams := map[string][]upstream.Upstream{}
 
@@ -51,7 +51,7 @@ func ParseUpstreamsConfig(upstreamConfig, bootstrapDNS []string, timeout time.Du
 			dnsUpstream, ok := upstreamsIndex[u]
 			if !ok {
 				// create an upstream
-				dnsUpstream, err = upstream.AddressToUpstream(u, upstream.Options{Bootstrap: bootstrapDNS, Timeout: timeout})
+				dnsUpstream, err = upstream.AddressToUpstream(u, upstream.Options{Bootstrap: bootstrapDNS, Timeout: timeout, InsecureSkipVerify: insecureSkipVerify})
 				if err != nil {
 					return UpstreamConfig{}, fmt.Errorf("cannot prepare the upstream %s (%s): %s", l, bootstrapDNS, err)
 				}

--- a/proxy/upstreams_test.go
+++ b/proxy/upstreams_test.go
@@ -1,6 +1,7 @@
 package proxy
 
 import (
+	"github.com/AdguardTeam/dnsproxy/upstream"
 	"testing"
 	"time"
 
@@ -10,7 +11,7 @@ import (
 func TestGetUpstreamsForDomain(t *testing.T) {
 	upstreams := []string{"[/google.com/local/]4.3.2.1", "[/www.google.com//]1.2.3.4", "[/maps.google.com/]#", "[/www.google.com/]tls://1.1.1.1"}
 
-	config, err := ParseUpstreamsConfig(upstreams, []string{}, 1*time.Second, false)
+	config, err := ParseUpstreamsConfig(upstreams, []string{}, 1*time.Second, upstream.Options{InsecureSkipVerify: false})
 	if err != nil {
 		t.Fatalf("Error while upstream config parsing: %s", err)
 	}
@@ -24,7 +25,7 @@ func TestGetUpstreamsForDomain(t *testing.T) {
 
 func TestGetUpstreamsForDomainWithoutDuplicates(t *testing.T) {
 	upstreams := []string{"[/example.com/]1.1.1.1", "[/example.org/]1.1.1.1"}
-	config, err := ParseUpstreamsConfig(upstreams, []string{}, 1*time.Second, false)
+	config, err := ParseUpstreamsConfig(upstreams, []string{}, 1*time.Second, upstream.Options{InsecureSkipVerify: false})
 	assert.Nil(t, err)
 	assert.Len(t, config.Upstreams, 0)
 	assert.Len(t, config.DomainReservedUpstreams, 2)

--- a/proxy/upstreams_test.go
+++ b/proxy/upstreams_test.go
@@ -11,7 +11,7 @@ import (
 func TestGetUpstreamsForDomain(t *testing.T) {
 	upstreams := []string{"[/google.com/local/]4.3.2.1", "[/www.google.com//]1.2.3.4", "[/maps.google.com/]#", "[/www.google.com/]tls://1.1.1.1"}
 
-	config, err := ParseUpstreamsConfig(upstreams, []string{}, 1*time.Second, upstream.Options{InsecureSkipVerify: false})
+	config, err := ParseUpstreamsConfig(upstreams, upstream.Options{InsecureSkipVerify: false, Bootstrap: []string{}, Timeout: 1 * time.Second})
 	if err != nil {
 		t.Fatalf("Error while upstream config parsing: %s", err)
 	}
@@ -25,7 +25,7 @@ func TestGetUpstreamsForDomain(t *testing.T) {
 
 func TestGetUpstreamsForDomainWithoutDuplicates(t *testing.T) {
 	upstreams := []string{"[/example.com/]1.1.1.1", "[/example.org/]1.1.1.1"}
-	config, err := ParseUpstreamsConfig(upstreams, []string{}, 1*time.Second, upstream.Options{InsecureSkipVerify: false})
+	config, err := ParseUpstreamsConfig(upstreams, upstream.Options{InsecureSkipVerify: false, Bootstrap: []string{}, Timeout: 1 * time.Second})
 	assert.Nil(t, err)
 	assert.Len(t, config.Upstreams, 0)
 	assert.Len(t, config.DomainReservedUpstreams, 2)

--- a/proxy/upstreams_test.go
+++ b/proxy/upstreams_test.go
@@ -10,7 +10,7 @@ import (
 func TestGetUpstreamsForDomain(t *testing.T) {
 	upstreams := []string{"[/google.com/local/]4.3.2.1", "[/www.google.com//]1.2.3.4", "[/maps.google.com/]#", "[/www.google.com/]tls://1.1.1.1"}
 
-	config, err := ParseUpstreamsConfig(upstreams, []string{}, 1*time.Second)
+	config, err := ParseUpstreamsConfig(upstreams, []string{}, 1*time.Second, false)
 	if err != nil {
 		t.Fatalf("Error while upstream config parsing: %s", err)
 	}
@@ -24,7 +24,7 @@ func TestGetUpstreamsForDomain(t *testing.T) {
 
 func TestGetUpstreamsForDomainWithoutDuplicates(t *testing.T) {
 	upstreams := []string{"[/example.com/]1.1.1.1", "[/example.org/]1.1.1.1"}
-	config, err := ParseUpstreamsConfig(upstreams, []string{}, 1*time.Second)
+	config, err := ParseUpstreamsConfig(upstreams, []string{}, 1*time.Second, false)
 	assert.Nil(t, err)
 	assert.Len(t, config.Upstreams, 0)
 	assert.Len(t, config.DomainReservedUpstreams, 2)


### PR DESCRIPTION
This PR covers https://github.com/AdguardTeam/dnsproxy/issues/94 to add a cli flag to disable TLS certificate validation.
