### PR TITLE
Implement draft-ietf-dprive-dnsoquic-02

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,9 +139,9 @@ Runs a DNS-over-HTTPS proxy on `127.0.0.1:443`.
 ./dnsproxy -l 127.0.0.1 --https-port=443 --tls-crt=example.crt --tls-key=example.key -u 8.8.8.8:53 -p 0
 ```
 
-Runs a DNS-over-QUIC proxy on `127.0.0.1:784`.
+Runs a DNS-over-QUIC proxy on `127.0.0.1:8853`.
 ```
-./dnsproxy -l 127.0.0.1 --quic-port=784 --tls-crt=example.crt --tls-key=example.key -u 8.8.8.8:53 -p 0
+./dnsproxy -l 127.0.0.1 --quic-port=8853 --tls-crt=example.crt --tls-key=example.key -u 8.8.8.8:53 -p 0
 ```
 
 Runs a DNSCrypt proxy on `127.0.0.1:443`.

--- a/proxy/proxy.go
+++ b/proxy/proxy.go
@@ -129,11 +129,11 @@ func (p *Proxy) Init() (err error) {
 	}
 
 	if p.TLSConfig != nil && len(p.TLSConfig.NextProtos) == 0 {
-		p.TLSConfig.NextProtos = []string{
+		p.TLSConfig.NextProtos = append([]string{
 			"http/1.1",
 			http2.NextProtoTLS,
 			NextProtoDQ,
-		}
+		}, compatProtoDQ...)
 		p.TLSConfig.NextProtos = append(p.TLSConfig.NextProtos, compatProtoDQ...)
 	}
 

--- a/proxy/server_quic.go
+++ b/proxy/server_quic.go
@@ -140,6 +140,7 @@ func (p *Proxy) handleQUICStream(stream quic.Stream, session quic.Session) {
 	// If any message sent on a DoQ connection contains an edns-tcp-keepalive EDNS(0) Option,
 	// this is a fatal error and the recipient of the defective message MUST forcibly abort
 	// the connection immediately.
+	// (https://tools.ietf.org/html/draft-ietf-dprive-dnsoquic-02#section-6.6.2)
 	if opt := msg.IsEdns0(); opt != nil {
 		for _, option := range opt.Option {
 			// Check for EDNS TCP keepalive option

--- a/proxy/server_quic.go
+++ b/proxy/server_quic.go
@@ -15,7 +15,7 @@ import (
 // NextProtoDQ - During connection establishment, DNS/QUIC support is indicated
 // by selecting the ALPN token "dq" in the crypto handshake.
 // Current draft version: https://tools.ietf.org/html/draft-ietf-dprive-dnsoquic-00
-const NextProtoDQ = "doq-i00"
+const NextProtoDQ = "doq-i02"
 
 // maxQuicIdleTimeout - maximum QUIC idle timeout.
 // Default value in quic-go is 30, but our internal tests show that
@@ -23,7 +23,7 @@ const NextProtoDQ = "doq-i00"
 const maxQuicIdleTimeout = 5 * time.Minute
 
 // compatProtoDQ - ALPNs for backwards compatibility
-var compatProtoDQ = []string{"dq", "doq"}
+var compatProtoDQ = []string{"doq-i00", "dq", "doq"}
 
 func (p *Proxy) createQUICListeners() error {
 	for _, a := range p.QUICListenAddr {

--- a/proxy/server_quic_test.go
+++ b/proxy/server_quic_test.go
@@ -26,7 +26,7 @@ func TestQuicProxy(t *testing.T) {
 	tlsConfig := &tls.Config{
 		ServerName: tlsServerName,
 		RootCAs:    roots,
-		NextProtos: []string{NextProtoDQ},
+		NextProtos: append([]string{NextProtoDQ}, compatProtoDQ...),
 	}
 
 	// Create a DNS-over-QUIC client connection

--- a/upstream/bootstrap.go
+++ b/upstream/bootstrap.go
@@ -18,7 +18,7 @@ import (
 
 // NextProtoDQ - During connection establishment, DNS/QUIC support is indicated
 // by selecting the ALPN token "dq" in the crypto handshake.
-const NextProtoDQ = "doq-i00"
+const NextProtoDQ = "doq-i02"
 
 // RootCAs is the CertPool that must be used by all upstreams
 // Redefining RootCAs makes sense on iOS to overcome the 15MB memory limit of the NEPacketTunnelProvider

--- a/upstream/bootstrap.go
+++ b/upstream/bootstrap.go
@@ -20,6 +20,9 @@ import (
 // by selecting the ALPN token "dq" in the crypto handshake.
 const NextProtoDQ = "doq-i02"
 
+// compatProtoDQ - ALPNs for backwards compatibility
+var compatProtoDQ = []string{"doq-i00", "dq", "doq"}
+
 // RootCAs is the CertPool that must be used by all upstreams
 // Redefining RootCAs makes sense on iOS to overcome the 15MB memory limit of the NEPacketTunnelProvider
 // nolint
@@ -191,9 +194,9 @@ func (n *bootstrapper) createTLSConfig(host string) *tls.Config {
 		VerifyPeerCertificate: n.options.VerifyServerCertificate,
 	}
 
-	tlsConfig.NextProtos = []string{
+	tlsConfig.NextProtos = append([]string{
 		"http/1.1", http2.NextProtoTLS, NextProtoDQ,
-	}
+	}, compatProtoDQ...)
 
 	return tlsConfig
 }

--- a/upstream/upstream.go
+++ b/upstream/upstream.go
@@ -114,10 +114,10 @@ func urlToUpstream(upstreamURL *url.URL, opts Options) (Upstream, error) {
 		return &plainDNS{address: getHostWithPort(upstreamURL, "53"), timeout: opts.Timeout, preferTCP: true}, nil
 	case "quic":
 		if upstreamURL.Port() == "" {
-			// https://tools.ietf.org/html/draft-ietf-dprive-dnsoquic-00#section-8.2.1
-			// Early experiments MAY use port 784.  This port is marked in the IANA
-			// registry as unassigned.
-			upstreamURL.Host += ":784"
+			//https://datatracker.ietf.org/doc/html/draft-ietf-dprive-dnsoquic-02#section-10.2.1
+			// Early experiments MAY use port 8853. This port is marked in the IANA registry as unassigned.
+			// (Note that prior to version -02 of this draft, experiments were directed to use port 784.)
+			upstreamURL.Host += ":8853"
 		}
 		resolverURL := upstreamURL.String()
 		b, err := urlToBoot(resolverURL, opts)

--- a/upstream/upstream_quic.go
+++ b/upstream/upstream_quic.go
@@ -37,6 +37,7 @@ func (p *dnsOverQUIC) Exchange(m *dns.Msg) (*dns.Msg, error) {
 	// If any message sent on a DoQ connection contains an edns-tcp-keepalive EDNS(0) Option,
 	// this is a fatal error and the recipient of the defective message MUST forcibly abort
 	// the connection immediately.
+	// (https://tools.ietf.org/html/draft-ietf-dprive-dnsoquic-02#section-6.6.2)
 	if opt := m.IsEdns0(); opt != nil {
 		for _, option := range opt.Option {
 			// Check for EDNS TCP keepalive option

--- a/upstream/upstream_quic.go
+++ b/upstream/upstream_quic.go
@@ -50,7 +50,7 @@ func (p *dnsOverQUIC) Exchange(m *dns.Msg) (*dns.Msg, error) {
 
 	// https://tools.ietf.org/html/draft-ietf-dprive-dnsoquic-02#section-6.4
 	// When sending queries over a QUIC connection, the DNS Message ID MUST be set to zero.
-	m.Id = 0
+	// m.Id = 0  // This breaks compatibility with proxies, and therefore must be disabled for dnsproxy.
 
 	stream, err := p.openStream(session)
 	if err != nil {

--- a/upstream/upstream_quic.go
+++ b/upstream/upstream_quic.go
@@ -47,6 +47,10 @@ func (p *dnsOverQUIC) Exchange(m *dns.Msg) (*dns.Msg, error) {
 		}
 	}
 
+	// https://tools.ietf.org/html/draft-ietf-dprive-dnsoquic-02#section-6.4
+	// When sending queries over a QUIC connection, the DNS Message ID MUST be set to zero.
+	m.Id = 0
+
 	stream, err := p.openStream(session)
 	if err != nil {
 		return nil, errorx.Decorate(err, "failed to open new stream to %s", p.Address())

--- a/upstream/upstream_quic_test.go
+++ b/upstream/upstream_quic_test.go
@@ -9,7 +9,7 @@ import (
 
 func TestUpstreamDOQ(t *testing.T) {
 	// Create a DNS-over-QUIC upstream
-	address := "quic://dns.adguard.com"
+	address := "quic://dns.adguard.com:784"
 	u, err := AddressToUpstream(address, Options{InsecureSkipVerify: true})
 	assert.Nil(t, err)
 

--- a/upstream/upstream_test.go
+++ b/upstream/upstream_test.go
@@ -185,7 +185,7 @@ func TestUpstreams(t *testing.T) {
 		},
 		{
 			// AdGuard DNS (DNS-over-QUIC)
-			address:   "sdns://BAcAAAAAAAAAAAAPZG5zLmFkZ3VhcmQuY29t",
+			address:   "sdns://BAcAAAAAAAAAAAATZG5zLmFkZ3VhcmQuY29tOjc4NA",
 			bootstrap: []string{"8.8.8.8:53"},
 		},
 		{
@@ -195,7 +195,7 @@ func TestUpstreams(t *testing.T) {
 		},
 		{
 			// Cloudflare DNS
-			address:   "quic://dns-unfiltered.adguard.com",
+			address:   "quic://dns-unfiltered.adguard.com:784",
 			bootstrap: []string{},
 		},
 	}


### PR DESCRIPTION
This PR implements the latest DNS-over-QUIC draft-ietf-dprive-dnsoquic-02, as mentioned in issue #127 