### PR TITLE
Update README.md about `--config-path` usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ Usage:
   dnsproxy [OPTIONS]
 
 Application Options:
-      --config-path      yaml configuration file.  Minimal working configuration
+      --config-path=     yaml configuration file.  Minimal working configuration
                          is given in the config.yaml.dist.  Passed command line
                          options will override the ones from the specified file.
   -v, --verbose          Verbose output (optional)


### PR DESCRIPTION
This will not work: `dnsproxy --config-path config.yaml`,
but this will work: `dnsproxy --config-path=config.yaml`