### PR TITLE
Remove DoH User-Agent header, close #211

### DIFF
--- a/upstream/upstream_doh.go
+++ b/upstream/upstream_doh.go
@@ -93,6 +93,7 @@ func (p *dnsOverHTTPS) exchangeHTTPSClient(m *dns.Msg, client *http.Client) (*dn
 	}
 
 	req.Header.Set("Accept", "application/dns-message")
+	req.Header.Set("User-Agent", "")
 
 	resp, err := client.Do(req)
 	if resp != nil && resp.Body != nil {


### PR DESCRIPTION
The current User-Agent string is: `Go-http-client/2.0`, as discussed in
issue #211, let's remove it for a little bit more privacy, just like
what Apple iOS and Mozilla Firefox already did!