### PR TITLE
add support for hyphen separated wildcard domains

### DIFF
--- a/proxy/upstreams.go
+++ b/proxy/upstreams.go
@@ -63,6 +63,11 @@ func ParseUpstreamsConfig(upstreamConfig []string, options *upstream.Options) (*
 
 					subdomainsOnlyExclusions.Add(host)
 					subdomainsOnlyUpstreams[host] = nil
+				} else if strings.HasPrefix(host, "*-") {
+					subdomainsOnlyUpstreams[host[len("*"):]] = nil
+
+					host = host[len("*-"):]
+					subdomainsOnlyExclusions.Add(host)
 				} else {
 					domainReservedUpstreams[host] = nil
 					specifiedDomainUpstreams[host] = nil
@@ -104,6 +109,12 @@ func ParseUpstreamsConfig(upstreamConfig []string, options *upstream.Options) (*
 					subdomainsOnlyExclusions.Add(host)
 					log.Debug("domain %s is added to exclusions list", host)
 
+					subdomainsOnlyUpstreams[host] = append(subdomainsOnlyUpstreams[host], dnsUpstream)
+				} else if strings.HasPrefix(host, "*-") {
+					subdomainsOnlyExclusions.Add(host[len("*-"):])
+					log.Debug("domain %s is added to exclusions list", host[len("*-"):])
+
+					host = host[len("*"):]
 					subdomainsOnlyUpstreams[host] = append(subdomainsOnlyUpstreams[host], dnsUpstream)
 				} else {
 					specifiedDomainUpstreams[host] = append(specifiedDomainUpstreams[host], dnsUpstream)
@@ -148,7 +159,9 @@ func parseUpstreamLine(l string) (string, []string, error) {
 		// split domains list
 		for _, confHost := range strings.Split(domainsAndUpstream[0], "/") {
 			if confHost != "" {
-				host := strings.TrimPrefix(confHost, "*.")
+				host := confHost
+				host = strings.TrimPrefix(host, "*.")
+				host = strings.TrimPrefix(host, "*-")
 				if err := netutil.ValidateDomainName(host); err != nil {
 					return "", nil, err
 				}
@@ -204,6 +217,14 @@ func (uc *UpstreamConfig) getUpstreamsForDomain(host string) (ups []upstream.Ups
 		name := h[i-1]
 
 		var ok bool
+
+		if i := strings.Index(name, "-"); i >= 0 {
+			ups, ok = uc.DomainReservedUpstreams[name[i:]]
+			if ok && len(ups) > 0 {
+				return ups
+			}
+		}
+
 		ups, ok = uc.DomainReservedUpstreams[name]
 		if !ok {
 			continue

--- a/proxy/upstreams_test.go
+++ b/proxy/upstreams_test.go
@@ -165,6 +165,8 @@ func TestGetUpstreamsForDomain_default_wildcards(t *testing.T) {
 		"[/*.example.org/]127.0.0.1:5303",
 		"[/www.example.org/]127.0.0.1:5304",
 		"[/*.www.example.org/]#",
+		"[/*-abc.example.org/]127.0.0.1:5305",
+		"[/*.abc.example.org/]127.0.0.1:5306",
 	}
 
 	uconf, err := ParseUpstreamsConfig(conf, nil)
@@ -190,6 +192,14 @@ func TestGetUpstreamsForDomain_default_wildcards(t *testing.T) {
 		name: "def_wildcard",
 		in:   "abc.www.example.org.",
 		want: []string{"127.0.0.1:5301"},
+	}, {
+		name: "hyphen_wildcard",
+		in:   "zxc-abc.example.org.",
+		want: []string{"127.0.0.1:5305"},
+	}, {
+		name: "sub_no_hyphen",
+		in:   "zxc.abc.example.org.",
+		want: []string{"127.0.0.1:5306"},
 	}}
 
 	for _, tc := range testCases {


### PR DESCRIPTION
Hello!

Please add support for wildcards separated by a hyphen as in dnsmasq.
For example, `*-dev.example.org` and `*-prod.example.org`

I need to use different upstreams for `something-dev.example.org` and `something-prod.example.org`