### PR TITLE
Add support for DoQ/DoH/DoT session resumption and 0-RTT

### DIFF
--- a/upstream/bootstrap.go
+++ b/upstream/bootstrap.go
@@ -212,8 +212,7 @@ func (n *bootstrapper) createTLSConfig(host string) *tls.Config {
 		tlsConfig.NextProtos = []string{http2.NextProtoTLS, "http/1.1"}
 	case "quic":
 		tlsConfig.NextProtos = compatProtoDQ
-		clientSessionCache := tls.NewLRUClientSessionCache(100)
-		tlsConfig.ClientSessionCache = clientSessionCache
+		tlsConfig.ClientSessionCache = tls.NewLRUClientSessionCache(10)
 	}
 
 	return tlsConfig

--- a/upstream/bootstrap.go
+++ b/upstream/bootstrap.go
@@ -212,6 +212,8 @@ func (n *bootstrapper) createTLSConfig(host string) *tls.Config {
 		tlsConfig.NextProtos = []string{http2.NextProtoTLS, "http/1.1"}
 	case "quic":
 		tlsConfig.NextProtos = compatProtoDQ
+		clientSessionCache := tls.NewLRUClientSessionCache(100)
+		tlsConfig.ClientSessionCache = clientSessionCache
 	}
 
 	return tlsConfig

--- a/upstream/bootstrap.go
+++ b/upstream/bootstrap.go
@@ -199,6 +199,7 @@ func (n *bootstrapper) createTLSConfig(host string) *tls.Config {
 		MinVersion:            tls.VersionTLS12,
 		InsecureSkipVerify:    n.options.InsecureSkipVerify,
 		VerifyPeerCertificate: n.options.VerifyServerCertificate,
+		ClientSessionCache:    tls.NewLRUClientSessionCache(1),
 	}
 
 	// Depending on the URL scheme, we choose what ALPN will be advertised by

--- a/upstream/upstream_quic.go
+++ b/upstream/upstream_quic.go
@@ -232,7 +232,7 @@ func (p *dnsOverQUIC) openConnection() (conn quic.Connection, err error) {
 		//
 		// TODO(ameshkov):  Consider making it configurable.
 		KeepAlivePeriod: 20 * time.Second,
-		TokenStore:	p.tokenStore,
+		TokenStore:      p.tokenStore,
 	}
 	conn, err = quic.DialAddrEarlyContext(context.Background(), addr, tlsConfig, quicConfig)
 	if err != nil {

--- a/upstream/upstream_quic.go
+++ b/upstream/upstream_quic.go
@@ -61,9 +61,8 @@ func newDoQ(uu *url.URL, opts *Options) (u Upstream, err error) {
 	if err != nil {
 		return nil, fmt.Errorf("creating quic bootstrapper: %w", err)
 	}
-	tokenStore := quic.NewLRUTokenStore(5, 50)
 
-	return &dnsOverQUIC{boot: b, tokenStore: tokenStore}, nil
+	return &dnsOverQUIC{boot: b, tokenStore: quic.NewLRUTokenStore(1, 10)}, nil
 }
 
 func (p *dnsOverQUIC) Address() string { return p.boot.URL.String() }

--- a/upstream/upstream_quic.go
+++ b/upstream/upstream_quic.go
@@ -235,7 +235,7 @@ func (p *dnsOverQUIC) openConnection() (conn quic.Connection, err error) {
 		KeepAlivePeriod: 20 * time.Second,
 		TokenStore:	p.tokenStore,
 	}
-	conn, err = quic.DialAddrContext(context.Background(), addr, tlsConfig, quicConfig)
+	conn, err = quic.DialAddrEarlyContext(context.Background(), addr, tlsConfig, quicConfig)
 	if err != nil {
 		return nil, fmt.Errorf("opening quic connection to %s: %w", p.Address(), err)
 	}


### PR DESCRIPTION
#### Motivation:
Subsequent DoQ/DoH/DoT connections within an upstream can be sped up by using session resumption or 0-RTT. To do so, the TLS configuration needs a session cache to store session tickets. Furthermore, DoQ may run into the address validation/Retry mechanism, which can be improved by using a token store.

#### Implementation:
Each DoQ upstream now has a token store and each bootstrapper creates a client session cache for DoQ, DoH and DoT upstreams. The token store is implemented for a single origin with a token capacity of 10 (can maybe be reduced?), the session cache has a ticket capacity of 1.

#### Notes:
An earlier implementation created the token store and session cache in main.go. However, to simplify the implementation a bit and to not have to deal with counting the number of upstreams, and to not interact with the bootstrap code too much, the implementation was changed to create the token store when the upstream is created and to create the session cache with the TLS configuration.

