### PR TITLE
Fix build on netbsd

### DIFF
--- a/upstream/upstream_dot_unix.go
+++ b/upstream/upstream_dot_unix.go
@@ -1,4 +1,4 @@
-//go:build darwin || freebsd || linux || openbsd
+//go:build darwin || freebsd || linux || openbsd || netbsd
 
 package upstream
 


### PR DESCRIPTION
Recent version 0.46.5 broke build on NetBSD (I use `upstream` package for another application). This PR adds proper build tag to make it buildable for NetBSD again.