### PR TITLE
update h3:// usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,7 +154,7 @@ DNS-over-HTTPS upstream with enabled HTTP/3 support (chooses it if it's faster):
 
 DNS-over-HTTPS upstream with forced HTTP/3 (no fallback to other protocol):
 ```shell
-./dnsproxy -u h3://dns.google/dns-query
+./dnsproxy -u h3://dns.google/dns-query --http3
 ```
 
 DNSCrypt upstream ([DNS Stamp](https://dnscrypt.info/stamps) of AdGuard DNS):


### PR DESCRIPTION
if using `-u h3://` without `--http3`, the debug log shows: `[debug] using HTTP/2 for this upstream: HTTP3 support is not enabled `, this is not the same as `DNS-over-HTTPS upstream with forced HTTP/3 (no fallback to other protocol):` describes.