### PR TITLE
Prevent reading from a nil response in DNS64

### DIFF
--- a/proxy/dns64.go
+++ b/proxy/dns64.go
@@ -302,6 +302,9 @@ func (p *Proxy) performDNS64(
 	origResp *dns.Msg,
 	upstreams []upstream.Upstream,
 ) (u upstream.Upstream) {
+	if origResp == nil {
+		return nil
+	}
 	dns64Req := p.checkDNS64(origReq, origResp)
 	if dns64Req == nil {
 		return nil


### PR DESCRIPTION
Sometimes if the upstream failed to be contacted, the return response will be empty.
DNSCrypts still wants to read the response code. This causes a panic if DNS64 is configured.