### PR TITLE
Make Server header for DoH server configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,7 @@ Application Options:
       --dns64                  If specified, dnsproxy will act as a DNS64 server
       --dns64-prefix=          Prefix used to handle DNS64. If not specified, dnsproxy uses the 'Well-Known Prefix' 64:ff9b::.
                                Can be specified multiple times
+      --https-server-name=     Set the Server header for the responses from the HTTPS server. (default: "dnsproxy")
       --ipv6-disabled          If specified, all AAAA requests will be replied with NoError RCode and empty answer
       --bogus-nxdomain=        Transform the responses containing at least a single IP that matches specified addresses
                                and CIDRs into NXDOMAIN.  Can be specified multiple times.

--- a/main.go
+++ b/main.go
@@ -167,7 +167,7 @@ type Options struct {
 	// --
 
 	// Set Server header for the HTTPS server
-	HTTPSServerName string `yaml:"https-server-name" long:"https-server-name" description:"Set the Server header for the responses from the HTTPS server. (default: \"AdGuard DNS\")"`
+	HTTPSServerName string `yaml:"https-server-name" long:"https-server-name" description:"Set the Server header for the responses from the HTTPS server. (default: \"dnsproxy\")"`
 
 	// If true, all AAAA requests will be replied with NoError RCode and empty answer
 	IPv6Disabled bool `yaml:"ipv6-disabled" long:"ipv6-disabled" description:"If specified, all AAAA requests will be replied with NoError RCode and empty answer" optional:"yes" optional-value:"true"`
@@ -315,7 +315,7 @@ func runPprof(options *Options) {
 // createProxyConfig creates proxy.Config from the command line arguments
 func createProxyConfig(options *Options) proxy.Config {
 	if options.HTTPSServerName == "" {
-		options.HTTPSServerName = "AdGuard DNS"
+		options.HTTPSServerName = "dnsproxy"
 	}
 
 	// Create the config

--- a/main.go
+++ b/main.go
@@ -166,6 +166,9 @@ type Options struct {
 	// Other settings and options
 	// --
 
+	// Set Server header for the HTTPS server
+	HTTPSServerName string `yaml:"https-server-name" long:"https-server-name" description:"Set the Server header for the responses from the HTTPS server. (default: \"AdGuard DNS\")"`
+
 	// If true, all AAAA requests will be replied with NoError RCode and empty answer
 	IPv6Disabled bool `yaml:"ipv6-disabled" long:"ipv6-disabled" description:"If specified, all AAAA requests will be replied with NoError RCode and empty answer" optional:"yes" optional-value:"true"`
 
@@ -311,6 +314,10 @@ func runPprof(options *Options) {
 
 // createProxyConfig creates proxy.Config from the command line arguments
 func createProxyConfig(options *Options) proxy.Config {
+	if options.HTTPSServerName == "" {
+		options.HTTPSServerName = "AdGuard DNS"
+	}
+
 	// Create the config
 	config := proxy.Config{
 		Ratelimit:       options.Ratelimit,
@@ -327,6 +334,7 @@ func createProxyConfig(options *Options) proxy.Config {
 		TrustedProxies:         []string{"0.0.0.0/0", "::0/0"},
 		EnableEDNSClientSubnet: options.EnableEDNSSubnet,
 		UDPBufferSize:          options.UDPBufferSize,
+		HTTPSServerName:        options.HTTPSServerName,
 		MaxGoroutines:          options.MaxGoRoutines,
 	}
 

--- a/proxy/config.go
+++ b/proxy/config.go
@@ -173,6 +173,9 @@ type Config struct {
 	// PreferIPv6 tells the proxy to prefer IPv6 addresses when bootstrapping
 	// upstreams that use hostnames.
 	PreferIPv6 bool
+
+	// HTTPSServerName sets the Server header of the HTTPS server responses.
+	HTTPSServerName string
 }
 
 // validateConfig verifies that the supplied configuration is valid and returns an error if it's not

--- a/proxy/server_https.go
+++ b/proxy/server_https.go
@@ -183,7 +183,7 @@ func (p *Proxy) respondHTTPS(d *DNSContext) error {
 		return fmt.Errorf("packing message: %w", err)
 	}
 
-	w.Header().Set("Server", "AdGuard DNS")
+	w.Header().Set("Server", p.Config.HTTPSServerName)
 	w.Header().Set("Content-Type", "application/dns-message")
 	_, err = w.Write(bytes)
 


### PR DESCRIPTION
This PR makes the Server header in the DoH server configurable, to make the `dnsproxy` instance admin to change the identifier of the DoH server.