### PR TITLE
Update example in README.

### DIFF
--- a/README.md
+++ b/README.md
@@ -221,7 +221,7 @@ Runs a DNS proxy on `0.0.0.0:53` with rate limit set to `10 rps`, enabled DNS ca
 
 Runs a DNS proxy on 127.0.0.1:5353 with multiple upstreams and enable parallel queries to all configured upstream servers.
 ```shell
-./dnsproxy -l 127.0.0.1 -p 5353 -u 8.8.8.8:53 -u 1.1.1.1:53 -u tls://dns.adguard.com --all-servers
+./dnsproxy -l 127.0.0.1 -p 5353 -u 8.8.8.8:53 -u 1.1.1.1:53 -u tls://dns.adguard.com --upstream-mode parallel
 ```
 
 Loads upstreams list from a file.


### PR DESCRIPTION
Replace `--all-servers` with `--upstream-mode parallel` in example to align with new version parameters.