### PR TITLE
fix: disable udp/tcp listener if port is set to 0

### DIFF
--- a/internal/cmd/proxy.go
+++ b/internal/cmd/proxy.go
@@ -368,6 +368,9 @@ func (conf *configuration) initListenAddrs(config *proxy.Config) (err error) {
 	}
 
 	for _, port := range conf.ListenPorts {
+		if port == 0 {
+			continue
+		}
 		for _, ip := range addrs {
 			addrPort := netip.AddrPortFrom(ip, uint16(port))
 


### PR DESCRIPTION
According to the documentation, setting the port to 0 should disable plain DNS handler (TCP/UDP), but the current implementation just starts the corresponding DNS on a random port, and this patch makes the program consistent with the documentation.