### PR TITLE
Added critially important notes for DNS64.

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ Usage of ./dnsproxy:
   --config-path=path
         YAML configuration file. Minimal working configuration in config.yaml.dist. Options passed through command line will override the ones from this file.
   --dns64
-        If specified, dnsproxy will act as a DNS64 server.
+        If specified, dnsproxy will act as a DNS64 (a.k.a. NAT64) server. This is a really bad idea to do on public or out-of-house, as it will break large parts of the internet on IPv6 clients in such circumstances.
   --dns64-prefix=subnet
         Prefix used to handle DNS64. If not specified, dnsproxy uses the 'Well-Known Prefix' 64:ff9b::.  Can be specified multiple times.
   --dnscrypt-config=path/-g path

--- a/internal/cmd/args.go
+++ b/internal/cmd/args.go
@@ -379,7 +379,7 @@ var commandLineOptions = []*commandLineOption{
 		valueType: "",
 	},
 	dns64Idx: {
-		description: "If specified, dnsproxy will act as a DNS64 server.",
+		description: "If specified, dnsproxy will act as a DNS64 (a.k.a. NAT64) server. This is a really bad idea to do on public or out-of-house, as it will break large parts of the internet on IPv6 clients in such circumstances.",
 		long:        "dns64",
 		short:       "",
 		valueType:   "",


### PR DESCRIPTION
Directly inspired by https://github.com/AdguardTeam/AdGuardHome/issues/7898 and https://github.com/AdguardTeam/AdGuardHome/issues/7904.

The dns64 settings in multiple AdGuard products, certainly including dnsproxy, does not properly explain at all what the setting does, and that it is in fact much more likely to break IPv6 sites than to handle them better.

T
r
u
s
t

m
e
•

It took me **years** to debug a very similar problem in AGH, and even then only because I received a fantastic tip in the firstmost-linked thread.