### PR TITLE
Implement random resolver option

### DIFF
--- a/internal/cmd/args.go
+++ b/internal/cmd/args.go
@@ -131,7 +131,7 @@ var commandLineOptions = []*commandLineOption{
 		valueType:   "address",
 	},
 	upstreamModeIdx: {
-		description: "Defines the upstreams logic mode, possible values: load_balance, parallel, " +
+		description: "Defines the upstreams logic mode, possible values: load_balance, parallel, random, " +
 			"fastest_addr (default: load_balance).",
 		long:      "upstream-mode",
 		short:     "",

--- a/proxy/config.go
+++ b/proxy/config.go
@@ -296,7 +296,8 @@ func (p *Proxy) validateConfig() (err error) {
 		"",
 		UpstreamModeFastestAddr,
 		UpstreamModeLoadBalance,
-		UpstreamModeParallel:
+		UpstreamModeParallel,
+		UpstreamModeRandom:
 		// Go on.
 	default:
 		return fmt.Errorf("upstream mode: %w: %q", errors.ErrBadEnumValue, p.UpstreamMode)

--- a/proxy/config.go
+++ b/proxy/config.go
@@ -296,8 +296,8 @@ func (p *Proxy) validateConfig() (err error) {
 		"",
 		UpstreamModeFastestAddr,
 		UpstreamModeLoadBalance,
-		UpstreamModeParallel,
-		UpstreamModeRandom:
+		UpstreamModeRandom,
+		UpstreamModeParallel:
 		// Go on.
 	default:
 		return fmt.Errorf("upstream mode: %w: %q", errors.ErrBadEnumValue, p.UpstreamMode)

--- a/proxy/exchange.go
+++ b/proxy/exchange.go
@@ -24,9 +24,9 @@ func (p *Proxy) exchangeUpstreams(
 	case UpstreamModeRandom:
 		// Simply set ups to a random entry in ups
 		// Falls back to default behaviour as if ups <= 1 it will run UpstreamModeLoadBalance as intended
-		if len(ups) > 1 {
-		    ups = []upstream.Upstream{ups[p.randSrc.Intn(len(ups))]}
-	    }
+	if len(ups) > 1 {
+		ups = []upstream.Upstream{ups[p.randSrc.Intn(len(ups))]}
+	}
 	case UpstreamModeFastestAddr:
 		switch req.Question[0].Qtype {
 		case dns.TypeA, dns.TypeAAAA:

--- a/proxy/exchange.go
+++ b/proxy/exchange.go
@@ -21,6 +21,12 @@ func (p *Proxy) exchangeUpstreams(
 	switch p.UpstreamMode {
 	case UpstreamModeParallel:
 		return upstream.ExchangeParallel(ups, req)
+	case UpstreamModeRandom:
+		// Simply set ups to a random entry in ups
+		// Falls back to default behaviour as if ups <= 1 it will run UpstreamModeLoadBalance as intended
+		if len(ups) > 1 {
+		    ups = []upstream.Upstream{ups[p.randSrc.Intn(len(ups))]}
+	    }
 	case UpstreamModeFastestAddr:
 		switch req.Question[0].Qtype {
 		case dns.TypeA, dns.TypeAAAA:

--- a/proxy/upstreammode.go
+++ b/proxy/upstreammode.go
@@ -38,7 +38,7 @@ func (m *UpstreamMode) UnmarshalText(b []byte) (err error) {
 	case
 		UpstreamModeLoadBalance,
 		UpstreamModeParallel,
-		UpstreamModeRandomm,
+		UpstreamModeRandom,
 		UpstreamModeFastestAddr:
 		*m = um
 	default:

--- a/proxy/upstreammode.go
+++ b/proxy/upstreammode.go
@@ -23,6 +23,9 @@ const (
 	// or AAAA requests only with the fastest IP address detected by ICMP
 	// response time or TCP connection time.
 	UpstreamModeFastestAddr UpstreamMode = "fastest_addr"
+
+    // UpstreamModeRandom makes server to a random upstream
+	UpstreamModeRandom UpstreamMode = "random"
 )
 
 // type check
@@ -35,6 +38,7 @@ func (m *UpstreamMode) UnmarshalText(b []byte) (err error) {
 	case
 		UpstreamModeLoadBalance,
 		UpstreamModeParallel,
+		UpstreamModeRandomm,
 		UpstreamModeFastestAddr:
 		*m = um
 	default:
@@ -43,6 +47,7 @@ func (m *UpstreamMode) UnmarshalText(b []byte) (err error) {
 			b,
 			UpstreamModeLoadBalance,
 			UpstreamModeParallel,
+			UpstreamModeRandom,
 			UpstreamModeFastestAddr,
 		)
 	}


### PR DESCRIPTION
Implements the option for a random resolver to go alongside this PR [https://github.com/AdguardTeam/AdGuardHome/pull/7950](https://github.com/AdguardTeam/AdGuardHome/pull/7950)

Hopefully resolves [https://github.com/AdguardTeam/AdGuardHome/issues/4756](https://github.com/AdguardTeam/AdGuardHome/issues/4756)