### PR TITLE
Upstream selection - Add the question for which an error occurs

### DIFF
--- a/proxy/proxy.go
+++ b/proxy/proxy.go
@@ -587,7 +587,7 @@ func (p *Proxy) replyFromUpstream(d *DNSContext) (ok bool, err error) {
 	if len(upstreams) == 0 {
 		d.Res = p.messages.NewMsgNXDOMAIN(req)
 
-		return false, fmt.Errorf("selecting upstream: %w", upstream.ErrNoUpstreams)
+		return false, fmt.Errorf("selecting upstream: %w for %q", upstream.ErrNoUpstreams, req.Question[0].Name)
 	}
 
 	if isPrivate {


### PR DESCRIPTION
In AdGuard Home, occasionally the error `selecting upstream: no upstream specified` is getting logged, but there's no way of knowing for which query it is logged. This PR aims to improve the message so that a correlation with client/domain name can be found that could possibly be used in the future to further improve upstream selection.

Thanks.

<img width="1588" height="806" alt="Image" src="https://github.com/user-attachments/assets/93b7eb5d-df15-417e-bdd0-6825dbce5641" />
