### PR TITLE
Prevent caching of responses resolved via fallback

### DIFF
--- a/proxy/optimisticresolver.go
+++ b/proxy/optimisticresolver.go
@@ -62,7 +62,11 @@ func (s *optimisticResolver) resolveOnce(dctx *DNSContext, key []byte, l *slog.L
 		l.Debug("resolving request for optimistic cache", slogutil.KeyError, err)
 	}
 
-	if ok {
+	if ok && !resolvedByFallback(dctx) {
 		s.cr.cacheResp(dctx)
 	}
+}
+
+func resolvedByFallback(dctx *DNSContext) (ok bool) {
+	return dctx.queryStatistics != nil && len(dctx.queryStatistics.Fallback()) > 0
 }


### PR DESCRIPTION
## Effect of this fix
After the fix:
- When the primary DNS is unavailable:
    - The client can still receive responses from the optimistic cache.
    - If the background refresh eventually uses the fallback DNS, that response will **not** overwrite the cache.

- When the primary DNS recovers:
    - The next successful background refresh through the primary DNS will update the cache.
    - The primary DNS response will be written back into the cache.
    - Subsequent requests will return cached results from the primary DNS again.

## Note
This fix changes one behavior:
**Fallback DNS responses will no longer refresh the cache TTL during optimistic cache refresh.**
This is usually expected, because fallback DNS is a failover path and should not continue to pollute the primary cache after the primary DNS has recovered.