### PR TITLE
proxy: normalize IDNA upstream domains

### DIFF
--- a/proxy/upstreams.go
+++ b/proxy/upstreams.go
@@ -23,6 +23,14 @@ const UnqualifiedNames = "unqualified_names"
 // labelSep is a separator between labels of a domain name.
 const labelSep = "."
 
+// domainSpecIDNA converts domains to their canonical lookup form while
+// preserving the permissive domain-name validation used by this parser.
+var domainSpecIDNA = idna.New(
+	idna.MapForLookup(),
+	idna.StrictDomainName(false),
+	idna.ValidateLabels(false),
+)
+
 // UpstreamConfig maps domain names to upstreams.
 type UpstreamConfig struct {
 	// DomainReservedUpstreams maps the domains to the upstreams.
@@ -231,7 +239,7 @@ func normalizeDomainSpec(domain string) (normalized string, err error) {
 		return "", err
 	}
 
-	domain, err = idna.ToASCII(domain)
+	domain, err = domainSpecIDNA.ToASCII(domain)
 	if err != nil {
 		return "", fmt.Errorf("converting to ASCII: %w", err)
 	}

--- a/proxy/upstreams.go
+++ b/proxy/upstreams.go
@@ -12,6 +12,7 @@ import (
 	"github.com/AdguardTeam/golibs/container"
 	"github.com/AdguardTeam/golibs/errors"
 	"github.com/AdguardTeam/golibs/netutil"
+	"golang.org/x/net/idna"
 )
 
 // UnqualifiedNames is a key for [UpstreamConfig.DomainReservedUpstreams] map to
@@ -221,6 +222,26 @@ func (p *configParser) parseLine(idx int, confLine string) (err error) {
 	return nil
 }
 
+// normalizeDomainSpec validates domain and returns its canonical ASCII form.
+func normalizeDomainSpec(domain string) (normalized string, err error) {
+	wildcard := strings.HasPrefix(domain, "*.")
+	domain = strings.TrimPrefix(domain, "*.")
+	err = netutil.ValidateDomainName(domain)
+	if err != nil {
+		return "", err
+	}
+
+	domain, err = idna.ToASCII(domain)
+	if err != nil {
+		return "", fmt.Errorf("converting to ASCII: %w", err)
+	}
+	if wildcard {
+		domain = "*." + domain
+	}
+
+	return strings.ToLower(domain + labelSep), nil
+}
+
 // splitConfigLine parses upstream configuration line and returns list upstream
 // addresses (one or many), list of domains for which this upstream is reserved
 // (may be nil).  It returns an error if the upstream format is incorrect.
@@ -243,12 +264,12 @@ func splitConfigLine(confLine string) (upstreams, domains []string, err error) {
 			continue
 		}
 
-		err = netutil.ValidateDomainName(strings.TrimPrefix(confHost, "*."))
+		confHost, err = normalizeDomainSpec(confHost)
 		if err != nil {
 			return nil, nil, fmt.Errorf("domain at index %d: %w", i, err)
 		}
 
-		domains = append(domains, strings.ToLower(confHost+labelSep))
+		domains = append(domains, confHost)
 	}
 
 	return strings.Fields(upstreamsLine), domains, nil

--- a/proxy/upstreams_internal_test.go
+++ b/proxy/upstreams_internal_test.go
@@ -125,11 +125,15 @@ func TestUpstreamConfig_GetUpstreamsForDomain_IDNA(t *testing.T) {
 	config, err := ParseUpstreamsConfig([]string{
 		generalUpstream,
 		"[/恒天.com/]" + idnaUpstream,
+		"[/GÖPHER.com/]" + idnaUpstream,
 	}, nil)
 	require.NoError(t, err)
 	testutil.CleanupAndRequireSuccess(t, config.Close)
 
 	ups := config.getUpstreamsForDomain("xn--rss99n.com.")
+	assertUpstreamsAddrs(t, ups, []string{idnaUpstream})
+
+	ups = config.getUpstreamsForDomain("xn--gpher-jua.com.")
 	assertUpstreamsAddrs(t, ups, []string{idnaUpstream})
 }
 

--- a/proxy/upstreams_internal_test.go
+++ b/proxy/upstreams_internal_test.go
@@ -117,6 +117,22 @@ func TestUpstreamConfig_GetUpstreamsForDomain(t *testing.T) {
 	}
 }
 
+func TestUpstreamConfig_GetUpstreamsForDomain_IDNA(t *testing.T) {
+	t.Parallel()
+
+	const idnaUpstream = "tcp://idna.upstream:53"
+
+	config, err := ParseUpstreamsConfig([]string{
+		generalUpstream,
+		"[/恒天.com/]" + idnaUpstream,
+	}, nil)
+	require.NoError(t, err)
+	testutil.CleanupAndRequireSuccess(t, config.Close)
+
+	ups := config.getUpstreamsForDomain("xn--rss99n.com.")
+	assertUpstreamsAddrs(t, ups, []string{idnaUpstream})
+}
+
 func TestUpstreamConfig_GetUpstreamsForDS(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
Updates AdguardTeam/AdGuardHome#2915.

Domain-specific upstream rules already validate internationalized domain names
through IDNA, but the parser stores the original Unicode spelling.  DNS
questions use the ASCII/Punycode form, so lookup cannot find that routing key
and silently falls back to the default upstream.

This change converts a validated domain specification to its canonical ASCII
form before storing it, while preserving wildcard semantics and the existing
validation errors.  The regression configures `[/恒天.com/]` and verifies that
a question for `xn--rss99n.com.` selects the reserved upstream; it fails against
the previous implementation by selecting the default upstream instead.

Validation:

- `go test -race -count=20 -run '^TestUpstreamConfig_GetUpstreamsForDomain_IDNA$' ./proxy`
- `go test -race -count=1 ./proxy`
- `make go-os-check` (Darwin, FreeBSD, OpenBSD, Linux, and Windows)
- `make go-lint` through `make go-check`; `govulncheck` reported no called
  vulnerabilities

`make go-check` did not complete locally because its unrelated live-upstream
tests repeatedly timed out or reset connections to `94.140.14.14:5353` and
`9.9.9.9`; all packages reached before those network integration cases passed.
The affected package and parser regression are fully green under the race
detector, and CI can provide the independent network-enabled run.
