### PR TITLE
proxy: report optimistic cache refreshes

### DIFF
--- a/proxy/config.go
+++ b/proxy/config.go
@@ -65,6 +65,19 @@ type Config struct {
 	// from this handler, the proxy will not send any response to the client.
 	RequestHandler Handler
 
+	// OnOptimisticRefresh is called, if not nil, once the optimistic cache has
+	// refreshed an expired entry in the background.  dctx is the context of
+	// that refresh; its [DNSContext.QueryStatistics] describe the exchanges it
+	// performed.  Implementations must not modify or retain dctx, and must not
+	// block.
+	//
+	// An optimistic cache hit is answered from the cache right away and the
+	// entry is refreshed in a separate goroutine, so the exchanges of that
+	// refresh never reach [Config.RequestHandler].  Without this callback there
+	// is no way to account for them, which biases any statistics collected from
+	// [DNSContext.QueryStatistics] towards cache misses.
+	OnOptimisticRefresh func(dctx *DNSContext)
+
 	// UpstreamConfig is a general set of DNS servers to forward requests to.
 	UpstreamConfig *UpstreamConfig
 

--- a/proxy/optimisticresolver.go
+++ b/proxy/optimisticresolver.go
@@ -19,6 +19,10 @@ type cachingResolver interface {
 
 	// cacheResp caches the response from dctx.
 	cacheResp(dctx *DNSContext)
+
+	// reportRefresh reports that dctx has been resolved in the background, so
+	// that the exchanges it performed can be accounted for.
+	reportRefresh(dctx *DNSContext)
 }
 
 // type check
@@ -61,6 +65,10 @@ func (s *optimisticResolver) resolveOnce(dctx *DNSContext, key []byte, l *slog.L
 	if err != nil {
 		l.Debug("resolving request for optimistic cache", slogutil.KeyError, err)
 	}
+
+	// Report the refresh even when it failed, since its statistics describe the
+	// attempt either way.
+	s.cr.reportRefresh(dctx)
 
 	if ok {
 		s.cr.cacheResp(dctx)

--- a/proxy/optimisticresolver_internal_test.go
+++ b/proxy/optimisticresolver_internal_test.go
@@ -15,6 +15,7 @@ import (
 type testCachingResolver struct {
 	onReplyFromUpstream func(dctx *DNSContext) (ok bool, err error)
 	onCacheResp         func(dctx *DNSContext)
+	onReportRefresh     func(dctx *DNSContext)
 }
 
 // replyFromUpstream implements the cachingResolver interface for
@@ -26,6 +27,14 @@ func (tcr *testCachingResolver) replyFromUpstream(dctx *DNSContext) (ok bool, er
 // cacheResp implements the cachingResolver interface for *testCachingResolver.
 func (tcr *testCachingResolver) cacheResp(dctx *DNSContext) {
 	tcr.onCacheResp(dctx)
+}
+
+// reportRefresh implements the cachingResolver interface for
+// *testCachingResolver.
+func (tcr *testCachingResolver) reportRefresh(dctx *DNSContext) {
+	if tcr.onReportRefresh != nil {
+		tcr.onReportRefresh(dctx)
+	}
 }
 
 func TestOptimisticResolver_ResolveOnce(t *testing.T) {
@@ -112,4 +121,58 @@ func TestOptimisticResolver_ResolveOnce_unsuccessful(t *testing.T) {
 
 		assert.False(t, cached)
 	})
+}
+
+func TestOptimisticResolver_ResolveOnce_reportRefresh(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		replyErr error
+		name     string
+		replyOK  bool
+		wantSet  bool
+	}{{
+		replyErr: nil,
+		name:     "success",
+		replyOK:  true,
+		wantSet:  true,
+	}, {
+		replyErr: assert.AnError,
+		name:     "failure",
+		replyOK:  false,
+		wantSet:  false,
+	}}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			var reported, set int
+			dctx := &DNSContext{}
+
+			s := newOptimisticResolver(&testCachingResolver{
+				onReplyFromUpstream: func(_ *DNSContext) (ok bool, err error) {
+					return tc.replyOK, tc.replyErr
+				},
+				onCacheResp: func(_ *DNSContext) { set++ },
+				onReportRefresh: func(got *DNSContext) {
+					assert.Same(t, dctx, got)
+
+					reported++
+				},
+			})
+
+			s.resolveOnce(dctx, []byte("key"), slog.New(slog.DiscardHandler))
+
+			// The refresh is reported whether or not it succeeded, since its
+			// statistics describe the attempt either way.
+			assert.Equal(t, 1, reported)
+
+			if tc.wantSet {
+				assert.Equal(t, 1, set)
+			} else {
+				assert.Equal(t, 0, set)
+			}
+		})
+	}
 }

--- a/proxy/proxycache.go
+++ b/proxy/proxycache.go
@@ -76,6 +76,14 @@ func cloneIPNet(n *net.IPNet) (clone *net.IPNet) {
 	}
 }
 
+// reportRefresh implements the [cachingResolver] interface for *Proxy.  It
+// notifies [Config.OnOptimisticRefresh], if it is set.
+func (p *Proxy) reportRefresh(d *DNSContext) {
+	if p.OnOptimisticRefresh != nil {
+		p.OnOptimisticRefresh(d)
+	}
+}
+
 // cacheResp stores the response from d in general or subnet cache.  In case the
 // cache is present in d, it's used first.
 func (p *Proxy) cacheResp(d *DNSContext) {


### PR DESCRIPTION
See https://github.com/AdguardTeam/AdGuardHome/issues/8435.

## Problem

An optimistic cache hit is answered from the cache immediately while the expired entry is refreshed in a separate goroutine. `Proxy.replyFromCache` builds a reduced clone of the context for that refresh:

```go
if dctxCache.optimistic && expired {
    minCtxClone := &DNSContext{ /* ... */ }
    go p.shortFlighter.resolveOnce(minCtxClone, key, p.logger)
}
```

`resolveOnce` calls `replyFromUpstream` on the clone, which fills in its `queryStatistics`, and then drops it. The refresh also never reaches `Config.RequestHandler`, since it bypasses `handleDNSRequest` entirely.

So a caller has no way to observe those exchanges. Anything collecting response times from `DNSContext.QueryStatistics` only ever samples cache misses — and with the optimistic cache enabled, the popular names are exactly the ones kept warm and therefore never sampled. The average ends up biased towards the rare names that upstreams resolve slower, which is what the AdGuard Home issue above reports as a 2-4x inflation.

## Change

An optional `Config.OnOptimisticRefresh`, called once a background refresh finishes, with the context carrying its statistics:

```go
// OnOptimisticRefresh is called, if not nil, once the optimistic cache has
// refreshed an expired entry in the background.  dctx is the context of
// that refresh; its [DNSContext.QueryStatistics] describe the exchanges it
// performed.  Implementations must not modify or retain dctx, and must not
// block.
OnOptimisticRefresh func(dctx *DNSContext)
```

It is routed through the existing `cachingResolver` seam that `optimisticResolver` already depends on, so `resolveOnce` gains one call and no new dependency. The refresh is reported whether or not it succeeded, since its statistics describe the attempt either way.

Nothing changes when the field is nil, which is every current caller.

## Why not wrap the upstreams

Wrapping `upstream.Upstream` and timing `Exchange` looks like it would avoid an API change, but it cannot attribute an exchange to the request it belongs to:

- `Exchange(req *dns.Msg)` takes no context and carries no per-request metadata.
- `ExchangeParallel` and `ExchangeAll` both do `req.Copy()` per upstream before calling it, so the identity of the original request does not survive — only the single-upstream path skips the copy.

A wrapper therefore cannot tell a background refresh from a client's query, nor apply per-client policy to what it records. That is what motivated adding the hook here rather than working around it downstream.

## Testing

`TestOptimisticResolver_ResolveOnce_reportRefresh` covers both the successful and the failed refresh, asserting the callback receives the same context and that caching still only happens on success.

`go build ./...`, `go vet ./...` and `gofmt` are clean, and `go test ./proxy/` passes except `TestExchangeWithReservedDomains`, which resolves `www.google.ru` against real upstreams and fails identically on a clean checkout here.
